### PR TITLE
Added allocations to schedulers

### DIFF
--- a/globalscheduler/controllers/distributor/BUILD
+++ b/globalscheduler/controllers/distributor/BUILD
@@ -59,9 +59,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["distributor_controller_test.go"],
+    srcs = [
+        "distributor_controller_test.go",
+        "distributor_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//globalscheduler/pkg/apis/allocation/v1:go_default_library",
+        "//globalscheduler/pkg/apis/cluster/v1:go_default_library",
         "//globalscheduler/pkg/apis/distributor/client/clientset/versioned/fake:go_default_library",
         "//globalscheduler/pkg/apis/distributor/client/informers/externalversions:go_default_library",
         "//globalscheduler/pkg/apis/distributor/v1:go_default_library",

--- a/globalscheduler/controllers/distributor/distributor_test.go
+++ b/globalscheduler/controllers/distributor/distributor_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 type Testcase struct {
-	SchedulerGeoLocation           clustercrdv1.GeolocationInfo
-	AllocationGeoLocation          allocv1.GeoLocation
-	ExpectedResult bool
+	SchedulerGeoLocation  clustercrdv1.GeolocationInfo
+	AllocationGeoLocation allocv1.GeoLocation
+	ExpectedResult        bool
 }
 
 func createSchedulerGeoLocation(city, province, area, country string) clustercrdv1.GeolocationInfo {
@@ -106,7 +106,7 @@ func TestIsAllocationGeoLocationMatched(t *testing.T) {
 		res := isAllocationGeoLocationMatched(&testcase.SchedulerGeoLocation, testcase.AllocationGeoLocation)
 		if res != testcase.ExpectedResult {
 			t.Errorf("The isAllocationGeoLocationMatched test result %v is not empty as expected with geoLocations %v, %v",
-				res, testcase.SchedulerGeoLocation, testcase.AllocationGeoLocation )
+				res, testcase.SchedulerGeoLocation, testcase.AllocationGeoLocation)
 		}
 	}
 }

--- a/globalscheduler/pkg/apis/allocation/v1/types.go
+++ b/globalscheduler/pkg/apis/allocation/v1/types.go
@@ -21,17 +21,18 @@ import (
 )
 
 const (
-	GroupName           string          = "globalscheduler.com"
-	Kind                string          = "Allocation"
-	Version             string          = "v1"
-	Plural              string          = "allocations"
-	Singluar            string          = "allocation"
-	ShortName           string          = "alloc"
-	Name                string          = Plural + "." + GroupName
-	AllocationAssigned  AllocationPhase = "Assigned"
-	AllocationBound     AllocationPhase = "Bound"
-	AllocationScheduled AllocationPhase = "Scheduled"
-	AllocationFailed    AllocationPhase = "Failed"
+	GroupName              string          = "globalscheduler.com"
+	Kind                   string          = "Allocation"
+	Version                string          = "v1"
+	Plural                 string          = "allocations"
+	Singluar               string          = "allocation"
+	ShortName              string          = "alloc"
+	Name                   string          = Plural + "." + GroupName
+	AllocationAssigned     AllocationPhase = "Assigned"
+	AllocationBound        AllocationPhase = "Bound"
+	AllocationScheduled    AllocationPhase = "Scheduled"
+	AllocationFailed       AllocationPhase = "Failed"
+	AllocationNotScheduled AllocationPhase = "NotScheduled"
 )
 
 // AllocationPhase is a label for the condition of an allocation at the current time.
@@ -75,9 +76,11 @@ type Resources struct {
 	Storage      Volume   `json:"storage,omitempty"`
 	NeedEip      bool     `json:"need_eip,omitempty"`
 	//Count        int      `json:"count,omitempty"` // It is commented because there is a conflict with replicas
-	Image           string `json:"image"`
-	SecurityGroupId string `json:"security_group_id"`
-	NicName         string `json:"nic_name"`
+	Image             string   `json:"image"`
+	SecurityGroupId   string   `json:"security_group_id"`
+	NicName           string   `json:"nic_name"`
+	ClusterNames      []string `json:"cluster_names"`
+	ClusterNamespaces []string `json:"cluster_namespaces"`
 }
 
 type Flavor struct {
@@ -93,9 +96,9 @@ type Spot struct {
 }
 
 type Volume struct {
-	SATA int `json:"sata,omitempty"` // default value 40
-	SAS  int `json:"sas,omitempty"`  // default value 10
-	SSD  int `json:"ssd,omitempty"`  // default value 10
+	SATA int64 `json:"sata,omitempty"` // default value 40
+	SAS  int64 `json:"sas,omitempty"`  // default value 10
+	SSD  int64 `json:"ssd,omitempty"`  // default value 10
 }
 
 type Selector struct {

--- a/globalscheduler/pkg/apis/allocation/v1/zz_generated.deepcopy.go
+++ b/globalscheduler/pkg/apis/allocation/v1/zz_generated.deepcopy.go
@@ -210,6 +210,16 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 		copy(*out, *in)
 	}
 	out.Storage = in.Storage
+	if in.ClusterNames != nil {
+		in, out := &in.ClusterNames, &out.ClusterNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ClusterNamespaces != nil {
+		in, out := &in.ClusterNamespaces, &out.ClusterNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/globalscheduler/pkg/scheduler/BUILD
+++ b/globalscheduler/pkg/scheduler/BUILD
@@ -10,6 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//globalscheduler/cmd/conf:go_default_library",
+        "//globalscheduler/pkg/apis/allocation/client/clientset/versioned:go_default_library",
+        "//globalscheduler/pkg/apis/allocation/v1:go_default_library",
         "//globalscheduler/pkg/apis/cluster/client/clientset/versioned:go_default_library",
         "//globalscheduler/pkg/apis/cluster/client/clientset/versioned/scheme:go_default_library",
         "//globalscheduler/pkg/apis/cluster/client/informers/externalversions:go_default_library",

--- a/globalscheduler/pkg/scheduler/scheduler.go
+++ b/globalscheduler/pkg/scheduler/scheduler.go
@@ -42,6 +42,8 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	cache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	allocclientset "k8s.io/kubernetes/globalscheduler/pkg/apis/allocation/client/clientset/versioned"
+	allocv1 "k8s.io/kubernetes/globalscheduler/pkg/apis/allocation/v1"
 	"k8s.io/kubernetes/globalscheduler/pkg/scheduler/algorithmprovider"
 	"k8s.io/kubernetes/globalscheduler/pkg/scheduler/client/typed"
 	"k8s.io/kubernetes/globalscheduler/pkg/scheduler/common/config"
@@ -110,6 +112,8 @@ type Scheduler struct {
 	//Cluster
 	KubeClientset          clientset.Interface //kubernetes.Interface
 	ApiextensionsClientset apiextensionsclientset.Interface
+	allocationClientset    allocclientset.Interface
+	allocationInformer     cache.SharedIndexInformer
 	ClusterClientset       clusterclientset.Interface
 	ClusterInformerFactory externalinformers.SharedInformerFactory
 	ClusterInformer        clusterinformers.ClusterInformer
@@ -151,8 +155,8 @@ func NewScheduler(gsconfig *types.GSSchedulerConfiguration, stopCh <-chan struct
 	//build entire FlavorMap map<flovorid, flavorinfo>
 	sched.UpdateFlavor()
 	klog.Infof("FlavorMap: %v", sched.siteCacheInfoSnapshot.FlavorMap)
-	// init pod, cluster, and scheduler informers for scheduler
-	err = sched.initPodClusterSchedulerInformers(gsconfig, stopEverything)
+	// init pod, cluster, scheduler, and allocation informers for scheduler
+	err = sched.initPodClusterSchedulerAllocationInformers(gsconfig, stopEverything)
 	if err != nil {
 		return nil, err
 	}
@@ -199,6 +203,11 @@ func (sched *Scheduler) StartInformersAndRun(stopCh <-chan struct{}) {
 	if sched.schedulerInformer != nil {
 		klog.Infof("Starting scheduler informer for scheduler %s", sched.SchedulerName)
 		go sched.schedulerInformer.Run(stopCh)
+	}
+	// start allocation informer
+	if sched.allocationInformer != nil {
+		klog.Infof("Starting allocation informer for scheduler %s", sched.SchedulerName)
+		go sched.allocationInformer.Run(stopCh)
 	}
 	// Do scheduling
 	sched.Run(sched.workerNumber, sched.workerNumber, stopCh)
@@ -636,13 +645,35 @@ func (sched *Scheduler) buildFramework() error {
 	return nil
 }
 
-// initPodInformers init scheduler with podInformer
-func (sched *Scheduler) initPodClusterSchedulerInformers(gsconfig *types.GSSchedulerConfiguration, stopCh <-chan struct{}) error {
+// initPodClusterSchedulerAllocationInformers init scheduler with podInformer, clusterInformer, schedulerInformer, and allocationInformer
+func (sched *Scheduler) initPodClusterSchedulerAllocationInformers(gsconfig *types.GSSchedulerConfiguration, stopCh <-chan struct{}) error {
 	// init kubeclient
 	cfg, err := clientcmd.BuildConfigFromFlags("", gsconfig.ConfigFilePath)
 	if err != nil {
 		return err
 	}
+
+	allocClientset, err := allocclientset.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	sched.allocationClientset = allocClientset
+	allocSelector := fields.ParseSelectorOrDie(fmt.Sprintf("status.phase=%s,status.scheduler_name=%s",
+		allocv1.AllocationAssigned, sched.SchedulerName))
+	allocLw := cache.NewListWatchFromClient(allocClientset.GlobalschedulerV1(), "allocations", metav1.NamespaceDefault, allocSelector)
+
+	sched.allocationInformer = cache.NewSharedIndexInformer(allocLw, &allocv1.Allocation{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	sched.allocationInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			alloc, ok := obj.(*allocv1.Allocation)
+			if !ok {
+				klog.Warningf("Failed to convert  object  %+v to an allocation", obj)
+				return
+			}
+			sched.scheduleAllocation(alloc)
+			sched.bindAllocation(alloc)
+		},
+	})
 
 	///cluster, apiextensions clientset to create crd programmatically
 	apiextensionsClientset, err := apiextensionsclientset.NewForConfig(cfg)
@@ -905,4 +936,137 @@ func (sched *Scheduler) UpdateRegionFlavor(region string, flavorId string) (err 
 	sched.siteCacheInfoSnapshot.RegionFlavorMap[regionFlavorId] = flavor
 	err = nil
 	return
+}
+
+// scheduleAllocation is to scheduler an allocv1.Allocation
+func (sched *Scheduler) scheduleAllocation(alloc *allocv1.Allocation) {
+	klog.Infof("Start to schedule the allocation %v.", alloc)
+	defer klog.Infof("End to schedule the allocation %v.", alloc)
+	clusterNames := make([]string, 0)
+	for idx, resource := range alloc.Spec.ResourceGroup.Resources {
+		if resource.ResourceType == "vm" {
+			stack := &types.Stack{
+				PodName:      resource.Name,
+				Tenant:       alloc.Tenant,
+				PodNamespace: alloc.Namespace,
+				UID:          uuid.NewV4().String(),
+				Selector:     getStackSelectorFromAllocation(&alloc.Spec.Selector),
+				Resources:    getStackResourcesFromAllocationResource(&resource),
+			}
+			allocation := &types.Allocation{
+				ID:       string(alloc.UID),
+				Stack:    *stack,
+				Replicas: alloc.Spec.Replicas,
+				Selector: stack.Selector,
+			}
+
+			//Schedule a converted allocation
+			tmpContext := context.Background()
+			result, err := sched.Schedule(tmpContext, allocation)
+			if err != nil {
+				klog.Errorf("Schedule failed, err: %s", err)
+				alloc.Status.Phase = allocv1.AllocationNotScheduled
+				return
+			}
+			klog.Infof("Try to bind to a cluster, stacks %v ", result.Stacks)
+			alloc.Spec.ResourceGroup.Resources[idx].ClusterNames = make([]string, 0)
+			alloc.Spec.ResourceGroup.Resources[idx].ClusterNamespaces = make([]string, 0)
+
+			for _, stack := range result.Stacks {
+				alloc.Spec.ResourceGroup.Resources[idx].ClusterNames =
+					append(alloc.Spec.ResourceGroup.Resources[idx].ClusterNames, stack.Selected.ClusterName)
+				alloc.Spec.ResourceGroup.Resources[idx].ClusterNamespaces =
+					append(alloc.Spec.ResourceGroup.Resources[idx].ClusterNamespaces, stack.Selected.ClusterNamespace)
+				clusterNames = append(clusterNames, stack.Selected.ClusterName)
+			}
+		}
+	}
+	alloc.Status.Phase = allocv1.AllocationScheduled
+	alloc.Status.ClusterNames = clusterNames
+}
+
+// getStackSelectorFromAllocation change allocation selector to stack selector
+func getStackSelectorFromAllocation(selector *allocv1.Selector) types.Selector {
+	// depress empty slice warning
+	var siteID string
+	newRegions := make([]types.CloudRegion, 0)
+	for _, region := range selector.Regions {
+		newRegions = append(newRegions, types.CloudRegion{
+			Region:           region.Region,
+			AvailabilityZone: region.AvailabilityZone,
+		})
+		/// the following check is to avoid an out of index error when allocation selector doesn't have az
+		siteID = region.Region + constants.SiteDelimiter
+		if len(region.AvailabilityZone) > 0 {
+			siteID = siteID + region.AvailabilityZone[0]
+		}
+	}
+
+	newSelector := types.Selector{
+		GeoLocation: types.GeoLocation{
+			Country:  selector.GeoLocation.Country,
+			Area:     selector.GeoLocation.Area,
+			Province: selector.GeoLocation.Province,
+			City:     selector.GeoLocation.City,
+		},
+		Regions:  newRegions,
+		Operator: selector.Operator,
+		SiteID:   siteID,
+		Strategy: types.Strategy{
+			LocationStrategy: selector.Strategy.LocationStrategy,
+		},
+	}
+	return newSelector
+}
+
+// getStackResourcesFromAllocationResource changes allocation resources to stack resource
+func getStackResourcesFromAllocationResource(allocRes *allocv1.Resources) []*types.Resource {
+	flavors := make([]types.Flavor, 0)
+	for _, flavor := range allocRes.Flavors {
+		flavors = append(flavors, types.Flavor{
+			FlavorID: flavor.FlavorId,
+			// Copied the following line from eventhandler.go
+			Spot: nil,
+			// Have to comment the following code segment since spot flavors are always empty
+			//Spot: &types.Spot{
+			//	flavor.Spot.MaxPrice,
+			//	flavor.Spot.SpotDurationCount,
+			//	flavor.Spot.SpotDurationHours,
+			//	flavor.Spot.InterruptionPolicy,
+			//	},
+		})
+	}
+	// Have to comment the following code segment since the test openstack does not support it.
+	//storageMap := make(map[string]int64)
+	//if allocRes.Storage.SAS > 0 {
+	//	storageMap["sas"] = allocRes.Storage.SAS
+	//}
+	//if allocRes.Storage.SATA > 0 {
+	//	storageMap["sata"] = allocRes.Storage.SATA
+	//}
+	//if allocRes.Storage.SSD > 0 {
+	//	storageMap["ssd"] = allocRes.Storage.SSD
+	//}
+	resource := &types.Resource{
+		Name:         allocRes.Name,
+		ResourceType: allocRes.ResourceType,
+		// Copied the following line from eventhandler.go
+		Storage: nil,
+		// Have to comment the following code segment since the test openstack does not support it.
+		//Storage:      storageMap,
+		Flavors: flavors,
+		NeedEip: allocRes.NeedEip,
+		// It is no longer used
+		Count: 1,
+	}
+	return []*types.Resource{resource}
+}
+
+// Update allocation status and bound cluster information
+func (sched *Scheduler) bindAllocation(alloc *allocv1.Allocation) {
+	if _, err := sched.allocationClientset.GlobalschedulerV1().AllocationsWithMultiTenancy(alloc.Namespace, alloc.Tenant).Update(alloc); err != nil {
+		klog.Errorf("Failed to update the allocation %v with the error %v", alloc, err)
+	} else {
+		klog.Infof("Updated allocation %s to the status phase %v successfully.", alloc.Name, alloc.Status.Phase)
+	}
 }

--- a/globalscheduler/test/yaml/sample_2_allocations.yaml
+++ b/globalscheduler/test/yaml/sample_2_allocations.yaml
@@ -32,7 +32,7 @@ spec:
     regions:
       - region: "NW-1"
         availability_zone: ["production-az"]
-    operator: chinamobile
+    operator: globalscheduler
     strategy:
       location_strategy: discrete
   replicas: 2
@@ -71,7 +71,7 @@ spec:
     regions:
       - region: "NE-1"
         availability_zone: ["production-az"]
-    operator: chinatelecom
+    operator: globalscheduler
     strategy:
       location_strategy: centralize
   replicas: 1

--- a/globalscheduler/test/yaml/sample_4_clusters.yaml
+++ b/globalscheduler/test/yaml/sample_4_clusters.yaml
@@ -14,12 +14,12 @@ spec:
     city: NewYork
     country: US
     province: NewYork
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler
   region:
-      availabilityzone: NE-1
+      availabilityzone: production-az
       region: NE-1
   serverprice: 10
   storage:
@@ -42,12 +42,12 @@ spec:
     city: Bellevue
     country: US
     province: Washington
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler
   region:
-      availabilityzone: NW-1
+      availabilityzone: production-az
       region: NW-1
   serverprice: 10
   storage:
@@ -70,7 +70,7 @@ spec:
     city: Orlando
     country: US
     province: Florida
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler
@@ -98,7 +98,7 @@ spec:
     city: Austin
     country: US
     province: Texas
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler
@@ -126,7 +126,7 @@ spec:
     city: Chicago
     country: US
     province: Illinois
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler
@@ -154,7 +154,7 @@ spec:
     city: Boston
     country: US
     province: Massachusettes
-  ipaddress: 34.220.41.107
+  ipaddress: 18.236.217.191
   memcapacity: 256
   operator:
       operator: globalscheduler


### PR DESCRIPTION
Added allocations to schedulers

Run "hack/globalscheduler/globalscheduler-up.sh"
Run "cluster/kubectl.sh apply -f globalscheduler/test/yaml/sample_2_schedulers.yaml"
Run "cluster/kubectl.sh apply -f globalscheduler/test/yaml/sample_4_clusters.yaml"
Run "cluster/kubectl.sh apply -f globalscheduler/test/yaml/sample_2_distributors.yaml"
Run "cluster/kubectl.sh apply -f globalscheduler/test/yaml/sample_2_allocations.yaml"
Run "cluster/kubectl.sh get allocations" and found the 2 allocations status phases have changed to "Scheduled"